### PR TITLE
Conditionally reference framework provided assemblies

### DIFF
--- a/src/IdentityModel.csproj
+++ b/src/IdentityModel.csproj
@@ -44,7 +44,6 @@
 
   <!--Conditional Package references -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>   	
   

--- a/src/IdentityModel.csproj
+++ b/src/IdentityModel.csproj
@@ -39,12 +39,14 @@
   
   <ItemGroup>
     <PackageReference Include="minver" Version="2.5.0" PrivateAssets="All" />
-
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
-
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
+
+  <!--Conditional Package references -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+  </ItemGroup>   	
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />


### PR DESCRIPTION
.net5.0 consumers shouldn't be forced to download a nuget package for an assembly that is already included