### PR TITLE
Perform maintenance on the unit tests project

### DIFF
--- a/src/IdentityModel.csproj
+++ b/src/IdentityModel.csproj
@@ -36,11 +36,11 @@
   </PropertyGroup>
 
   <!--Conditional compilation-->
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>net462;net472;netstandard2.0;net6.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+  <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFrameworks>net462;net472;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>

--- a/test/UnitTests/HttpClientExtensions/PushedAuthorizationTests.cs
+++ b/test/UnitTests/HttpClientExtensions/PushedAuthorizationTests.cs
@@ -188,7 +188,7 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Pushed_authorization_without_response_type_should_fail()
+        public async Task Pushed_authorization_without_response_type_should_fail()
         {
             var document = File.ReadAllText(FileName.Create("success_par_response.json"));
             var handler = new NetworkHandler(document, HttpStatusCode.OK);
@@ -198,11 +198,11 @@ namespace IdentityModel.UnitTests
 
             Func<Task> act = async () => await client.PushAuthorizationAsync(Request);
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("response_type");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("response_type");
         }
 
         [Fact]
-        public void Pushed_authorization_with_request_uri_should_fail()
+        public async Task Pushed_authorization_with_request_uri_should_fail()
         {
             var document = File.ReadAllText(FileName.Create("success_par_response.json"));
             var handler = new NetworkHandler(document, HttpStatusCode.OK);
@@ -213,7 +213,7 @@ namespace IdentityModel.UnitTests
 
             Func<Task> act = async () => await client.PushAuthorizationAsync(Request);
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("request_uri");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("request_uri");
         }
     }
 }

--- a/test/UnitTests/HttpClientExtensions/TokenIntrospectionTests.cs
+++ b/test/UnitTests/HttpClientExtensions/TokenIntrospectionTests.cs
@@ -219,7 +219,7 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Request_without_token_should_fail()
+        public async Task Request_without_token_should_fail()
         {
             var document = File.ReadAllText(FileName.Create("success_introspection_response.json"));
             var handler = new NetworkHandler(document, HttpStatusCode.OK);
@@ -231,7 +231,7 @@ namespace IdentityModel.UnitTests
 
             Func<Task> act = async () => await client.IntrospectTokenAsync(new TokenIntrospectionRequest());
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("token");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("token");
         }
 
         [Fact]

--- a/test/UnitTests/HttpClientExtensions/TokenRequestExtensionsRequestTests.cs
+++ b/test/UnitTests/HttpClientExtensions/TokenRequestExtensionsRequestTests.cs
@@ -221,13 +221,13 @@ namespace IdentityModel.UnitTests
 
 
         [Fact]
-        public void Explicit_null_parameters_should_not_fail_()
+        public async Task Explicit_null_parameters_should_not_fail_()
         {
             Func<Task> act = async () =>
                 await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
                     { ClientId = "client", Parameters = null });
 
-            act.Should().NotThrow();
+            await act.Should().NotThrowAsync();
         }
 
         [Fact]
@@ -250,12 +250,12 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Device_request_without_device_code_should_fail()
+        public async Task Device_request_without_device_code_should_fail()
         {
             Func<Task> act = async () =>
                 await _client.RequestDeviceTokenAsync(new DeviceTokenRequest { ClientId = "device" });
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("device_code");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("device_code");
         }
 
         [Fact]
@@ -314,11 +314,11 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Password_request_without_username_should_fail()
+        public async Task Password_request_without_username_should_fail()
         {
             Func<Task> act = async () => await _client.RequestPasswordTokenAsync(new PasswordTokenRequest());
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("username");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("username");
         }
 
         [Fact]
@@ -355,7 +355,7 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Code_request_without_code_should_fail()
+        public async Task Code_request_without_code_should_fail()
         {
             Func<Task> act = async () => await _client.RequestAuthorizationCodeTokenAsync(
                 new AuthorizationCodeTokenRequest
@@ -363,11 +363,11 @@ namespace IdentityModel.UnitTests
                     RedirectUri = "uri"
                 });
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("code");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("code");
         }
 
         [Fact]
-        public void Code_request_without_redirect_uri_should_fail()
+        public async Task Code_request_without_redirect_uri_should_fail()
         {
             Func<Task> act = async () => await _client.RequestAuthorizationCodeTokenAsync(
                 new AuthorizationCodeTokenRequest
@@ -375,7 +375,7 @@ namespace IdentityModel.UnitTests
                     Code = "code"
                 });
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("redirect_uri");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("redirect_uri");
         }
 
         [Fact]
@@ -408,11 +408,11 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Refresh_request_without_refresh_token_should_fail()
+        public async Task Refresh_request_without_refresh_token_should_fail()
         {
             Func<Task> act = async () => await _client.RequestRefreshTokenAsync(new RefreshTokenRequest());
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("refresh_token");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("refresh_token");
         }
 
         [Fact]
@@ -492,11 +492,11 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Setting_no_grant_type_should_fail()
+        public async Task Setting_no_grant_type_should_fail()
         {
             Func<Task> act = async () => await _client.RequestTokenAsync(new TokenRequest());
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("grant_type");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("grant_type");
         }
 
         [Fact]

--- a/test/UnitTests/Infrastructure/FileName.cs
+++ b/test/UnitTests/Infrastructure/FileName.cs
@@ -2,20 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace IdentityModel.UnitTests
 {
     internal static class FileName
     {
-        public static string Create(string name)
-        {
-#if NETCOREAPP2_1 || NETCOREAPP3_1 || NET5_0 || NET6_0 || NET7_0 || NET8_0
-            var fullName = Path.Combine(System.AppContext.BaseDirectory, "documents", name);
-#else
-            var fullName = Path.Combine(Microsoft.Extensions.PlatformAbstractions.PlatformServices.Default.Application.ApplicationBasePath, "documents", name);
-#endif
+        public static string Create(string name) => Path.Combine(UnitTestsPath(), "documents", name);
 
-            return fullName;
-        }
+        private static string UnitTestsPath([CallerFilePath] string path = "") => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(path), ".."));
     }
 }

--- a/test/UnitTests/TokenClientRequestTests.cs
+++ b/test/UnitTests/TokenClientRequestTests.cs
@@ -78,13 +78,13 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Device_request_without_device_code_should_fail()
+        public async Task Device_request_without_device_code_should_fail()
         {
             var tokenClient = new TokenClient(_client, new TokenClientOptions { ClientId = "device" });
 
             Func<Task> act = async () => await tokenClient.RequestDeviceTokenAsync(null);
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("device_code");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("device_code");
         }
 
         [Fact]
@@ -131,13 +131,13 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Password_request_without_username_should_fail()
+        public async Task Password_request_without_username_should_fail()
         {
             var tokenClient = new TokenClient(_client, new TokenClientOptions());
 
             Func<Task> act = async () => await tokenClient.RequestPasswordTokenAsync(userName: null);
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("username");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("username");
         }
 
         [Fact]
@@ -164,23 +164,23 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Code_request_without_code_should_fail()
+        public async Task Code_request_without_code_should_fail()
         {
             var tokenClient = new TokenClient(_client, new TokenClientOptions());
 
             Func<Task> act = async () => await tokenClient.RequestAuthorizationCodeTokenAsync(code: null, redirectUri: "uri", codeVerifier: "verifier");
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("code");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("code");
         }
 
         [Fact]
-        public void Code_request_without_redirect_uri_should_fail()
+        public async Task Code_request_without_redirect_uri_should_fail()
         {
             var tokenClient = new TokenClient(_client, new TokenClientOptions());
 
             Func<Task> act = async () => await tokenClient.RequestAuthorizationCodeTokenAsync(code: "code", redirectUri: null, codeVerifier: "verifier");
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("redirect_uri");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("redirect_uri");
         }
 
         [Fact]
@@ -204,23 +204,23 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Refresh_request_without_refresh_token_should_fail()
+        public async Task Refresh_request_without_refresh_token_should_fail()
         {
             var tokenClient = new TokenClient(_client, new TokenClientOptions());
 
             Func<Task> act = async () => await tokenClient.RequestRefreshTokenAsync(refreshToken: null, scope: "scope");
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("refresh_token");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("refresh_token");
         }
 
         [Fact]
-        public void Setting_no_grant_type_should_fail()
+        public async Task Setting_no_grant_type_should_fail()
         {
             var tokenClient = new TokenClient(_client, new TokenClientOptions());
 
             Func<Task> act = async () => await tokenClient.RequestTokenAsync(grantType: null);
 
-            act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("grant_type");
+            (await act.Should().ThrowAsync<ArgumentException>()).WithParameterName("grant_type");
         }
 
         [Fact]

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -25,10 +25,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
-        <PackageReference Include="xunit" Version="2.7.0" />
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" PrivateAssets="All" />
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or $(TargetFramework) == 'net472'">

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -24,18 +24,14 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
         <PackageReference Include="xunit" Version="2.7.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' or $(TargetFramework) == 'net7.0' or $(TargetFramework) == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    </ItemGroup>
-
     <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or $(TargetFramework) == 'net472'">
         <Reference Include="System.Net.Http" />
-        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     </ItemGroup>
 </Project>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -7,16 +7,11 @@
     </PropertyGroup>
 
     <!--Conditional compilation-->
-    <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-        <TargetFrameworks>net462;net472;net6.0;net7.0;net8.0</TargetFrameworks>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' and '$(NETCoreSdkPortableRuntimeIdentifier)' != 'osx-arm64' ">
+    <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(NETCoreSdkPortableRuntimeIdentifier)' == 'osx-arm64' ">
-        <TargetFrameworks>net6.0</TargetFrameworks>
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+        <TargetFrameworks>net462;net472;$(TargetFrameworks)</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -3,6 +3,7 @@
         <IsPackable>false</IsPackable>
         <AssemblyOriginatorKeyFile>../../key.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
+        <DeterministicSourcePaths>false</DeterministicSourcePaths>
     </PropertyGroup>
 
     <!--Conditional compilation-->
@@ -17,12 +18,6 @@
     <PropertyGroup Condition=" '$(NETCoreSdkPortableRuntimeIdentifier)' == 'osx-arm64' ">
         <TargetFrameworks>net6.0</TargetFrameworks>
     </PropertyGroup>
-
-    <ItemGroup>
-        <None Update="documents\*">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\IdentityModel.csproj" />
@@ -40,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or $(TargetFramework) == 'net472'">
-        <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
+        <Reference Include="System.Net.Http" />
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
* Remove the dependency on `Microsoft.Extensions.PlatformAbstraction` and use [CallerFilePath] in order to get the path to the test documents, making it unnecessary to copy the files from the `documents` directory to the output directory.
* Remove conditions around `Microsoft.AspNetCore.WebUtilities` (it was unnecessary)
* Update all test dependencies and adapt the tests for FluentAssertions 6 breaking changes.
* Simplify the definition of the target frameworks by removing conditional compilation around osx-arm64

Also avoid duplicating the .NET target framework but add `net462` and `net472` when running on Windows (on both the main and unit tests projects).