### PR TITLE
Improve HttpClient extension methods to help eliminate memory leak by not disposing of HttpResponseMessage

### DIFF
--- a/src/Client/Extensions/HttpClientBackchannelAuthenticationExtensions.cs
+++ b/src/Client/Extensions/HttpClientBackchannelAuthenticationExtensions.cs
@@ -14,60 +14,61 @@ namespace IdentityModel.Client;
 /// </summary>
 public static class HttpClientBackchannelAuthenticationExtensions
 {
-    /// <summary>
-    /// Sends a CIBA backchannel authentication request
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<BackchannelAuthenticationResponse> RequestBackchannelAuthenticationAsync(this HttpMessageInvoker client, BackchannelAuthenticationRequest request, CancellationToken cancellationToken = default)
+  /// <summary>
+  /// Sends a CIBA backchannel authentication request
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<BackchannelAuthenticationResponse> RequestBackchannelAuthenticationAsync(this HttpMessageInvoker client, BackchannelAuthenticationRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    if (!string.IsNullOrWhiteSpace(request.RequestObject))
     {
-        var clone = request.Clone();
-
-        if (!string.IsNullOrWhiteSpace(request.RequestObject))
-        {
-            clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.Request, request.RequestObject);
-        }
-        else
-        {
-            clone.Parameters.AddRequired(OidcConstants.AuthorizeRequest.Scope, request.Scope);
-            clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.ClientNotificationToken, request.ClientNotificationToken);
-            clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.AcrValues, request.AcrValues);
-            clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.LoginHintToken, request.LoginHintToken);
-            clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.LoginHint, request.LoginHint);
-            clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.IdTokenHint, request.IdTokenHint);
-            clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.BindingMessage, request.BindingMessage);
-            clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.UserCode, request.UserCode);
-        
-            if (request.RequestedExpiry.HasValue)
-            {
-                clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.RequestedExpiry, request.RequestedExpiry.ToString());    
-            }  
-            
-            foreach (var resource in request.Resource)
-            {
-                clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
-            }
-        }
-        
-        clone.Method = HttpMethod.Post;
-        clone.Prepare();
-                        
-        HttpResponseMessage response;
-        try
-        {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            return ProtocolResponse.FromException<BackchannelAuthenticationResponse>(ex);
-        }
-
-        return await ProtocolResponse.FromHttpResponseAsync<BackchannelAuthenticationResponse>(response).ConfigureAwait();
+      clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.Request, request.RequestObject);
     }
+    else
+    {
+      clone.Parameters.AddRequired(OidcConstants.AuthorizeRequest.Scope, request.Scope);
+      clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.ClientNotificationToken, request.ClientNotificationToken);
+      clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.AcrValues, request.AcrValues);
+      clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.LoginHintToken, request.LoginHintToken);
+      clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.LoginHint, request.LoginHint);
+      clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.IdTokenHint, request.IdTokenHint);
+      clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.BindingMessage, request.BindingMessage);
+      clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.UserCode, request.UserCode);
+
+      if (request.RequestedExpiry.HasValue)
+      {
+        clone.Parameters.AddOptional(OidcConstants.BackchannelAuthenticationRequest.RequestedExpiry, request.RequestedExpiry.ToString());
+      }
+
+      foreach (var resource in request.Resource)
+      {
+        clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
+      }
+    }
+
+    clone.Method = HttpMethod.Post;
+    clone.Prepare();
+
+
+    try
+    {
+      using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+      return await ProtocolResponse.FromHttpResponseAsync<BackchannelAuthenticationResponse>(response).ConfigureAwait();
+
+    }
+    catch (OperationCanceledException)
+    {
+      throw;
+    }
+    catch (Exception ex)
+    {
+      return ProtocolResponse.FromException<BackchannelAuthenticationResponse>(ex);
+    }
+
+  }
 }

--- a/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
+++ b/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
@@ -14,134 +14,134 @@ namespace IdentityModel.Client;
 /// </summary>
 public static class HttpClientDiscoveryExtensions
 {
-    /// <summary>
-    /// Sends a discovery document request
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="address">The address.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<DiscoveryDocumentResponse> GetDiscoveryDocumentAsync(this HttpClient client, string? address = null, CancellationToken cancellationToken = default)
+  /// <summary>
+  /// Sends a discovery document request
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="address">The address.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<DiscoveryDocumentResponse> GetDiscoveryDocumentAsync(this HttpClient client, string? address = null, CancellationToken cancellationToken = default)
+  {
+    if (address == null && client.BaseAddress == null)
+      throw new ArgumentException("Either the address parameter or the HttpClient BaseAddress must not be null.");
+    return await client.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest { Address = address }, cancellationToken).ConfigureAwait();
+  }
+
+  /// <summary>
+  /// Sends a discovery document request
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<DiscoveryDocumentResponse> GetDiscoveryDocumentAsync(this HttpMessageInvoker client, DiscoveryDocumentRequest request, CancellationToken cancellationToken = default)
+  {
+    string address;
+    if (request.Address.IsPresent())
     {
-        if (address == null && client.BaseAddress == null)
-            throw new ArgumentException("Either the address parameter or the HttpClient BaseAddress must not be null.");
-        return await client.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest { Address = address }, cancellationToken).ConfigureAwait();
+      address = request.Address!;
+    }
+    else if (client is HttpClient httpClient && httpClient.BaseAddress != null)
+    {
+      address = httpClient.BaseAddress!.AbsoluteUri;
+    }
+    else
+    {
+      throw new ArgumentException("Either the DiscoveryDocumentRequest Address or the HttpClient BaseAddress must not be null.");
     }
 
-    /// <summary>
-    /// Sends a discovery document request
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<DiscoveryDocumentResponse> GetDiscoveryDocumentAsync(this HttpMessageInvoker client, DiscoveryDocumentRequest request, CancellationToken cancellationToken = default)
+    var parsed = DiscoveryEndpoint.ParseUrl(address, request.Policy.DiscoveryDocumentPath);
+    var authority = parsed.Authority;
+    var url = parsed.Url;
+
+    if (request.Policy.Authority.IsMissing())
     {
-        string address;
-        if (request.Address.IsPresent())
-        {
-            address = request.Address!;
-        }
-        else if (client is HttpClient httpClient && httpClient.BaseAddress != null)
-        {
-            address = httpClient.BaseAddress!.AbsoluteUri;
-        }
-        else
-        {
-            throw new ArgumentException("Either the DiscoveryDocumentRequest Address or the HttpClient BaseAddress must not be null.");
-        }
-
-        var parsed = DiscoveryEndpoint.ParseUrl(address, request.Policy.DiscoveryDocumentPath);
-        var authority = parsed.Authority;
-        var url = parsed.Url;
-
-        if (request.Policy.Authority.IsMissing())
-        {
-            request.Policy.Authority = authority;
-        }
-
-        var jwkUrl = "";
-
-        if (!DiscoveryEndpoint.IsSecureScheme(new Uri(url), request.Policy))
-        {
-            return ProtocolResponse.FromException<DiscoveryDocumentResponse>(new InvalidOperationException("HTTPS required"), $"Error connecting to {url}. HTTPS required.");
-        }
-
-        try
-        {
-            var clone = request.Clone();
-
-            clone.Method = HttpMethod.Get;
-            clone.Prepare();
-
-            clone.RequestUri = new Uri(url);
-
-            var response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
-
-            if (!response.IsSuccessStatusCode)
-            {
-                return await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(response, $"Error connecting to {url}: {response.ReasonPhrase}").ConfigureAwait();
-            }
-
-            var disco = await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(response, request.Policy).ConfigureAwait();
-
-            if (disco.IsError)
-            {
-                return disco;
-            }
-
-            try
-            {
-                jwkUrl = disco.JwksUri;
-                if (jwkUrl != null)
-                {
-                    var jwkClone = request.Clone<JsonWebKeySetRequest>();
-                    jwkClone.Method = HttpMethod.Get;
-                    jwkClone.Address = jwkUrl;
-                    jwkClone.Prepare();
-
-                    var jwkResponse = await client.GetJsonWebKeySetAsync(jwkClone, cancellationToken).ConfigureAwait();
-
-                    if (jwkResponse.IsError)
-                    {
-                        if (jwkResponse.Exception != null)
-                        {
-                            return ProtocolResponse.FromException<DiscoveryDocumentResponse>(jwkResponse.Exception, jwkResponse.Error);
-                        }
-                        else if(jwkResponse.HttpResponse != null)
-                        {
-                            return await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(jwkResponse.HttpResponse, $"Error connecting to {jwkUrl}: {jwkResponse.HttpErrorReason}").ConfigureAwait();
-                        }
-                        // If IsError is true, but we have neither an Exception nor an HttpResponse, something very weird is going on
-                        // I don't think it is actually possible for this to occur, but just in case...
-                        else
-                        {
-                            return ProtocolResponse.FromException<DiscoveryDocumentResponse>(
-                                new ArgumentNullException(nameof(jwkResponse.HttpResponse)), $"Unknown error retrieving JWKS - neither an exception nor an HttpResponse is available");
-                        }
-                    }
-
-                    disco.KeySet = jwkResponse.KeySet;
-                }
-
-                return disco;
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                return ProtocolResponse.FromException<DiscoveryDocumentResponse>(ex, $"Error connecting to {jwkUrl}. {ex.Message}.");
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            return ProtocolResponse.FromException<DiscoveryDocumentResponse>(ex, $"Error connecting to {url}. {ex.Message}.");
-        }
+      request.Policy.Authority = authority;
     }
+
+    var jwkUrl = "";
+
+    if (!DiscoveryEndpoint.IsSecureScheme(new Uri(url), request.Policy))
+    {
+      return ProtocolResponse.FromException<DiscoveryDocumentResponse>(new InvalidOperationException("HTTPS required"), $"Error connecting to {url}. HTTPS required.");
+    }
+
+    try
+    {
+      var clone = request.Clone();
+
+      clone.Method = HttpMethod.Get;
+      clone.Prepare();
+
+      clone.RequestUri = new Uri(url);
+
+      using var response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+
+      if (!response.IsSuccessStatusCode)
+      {
+        return await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(response, $"Error connecting to {url}: {response.ReasonPhrase}").ConfigureAwait();
+      }
+
+      var disco = await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(response, request.Policy).ConfigureAwait();
+
+      if (disco.IsError)
+      {
+        return disco;
+      }
+
+      try
+      {
+        jwkUrl = disco.JwksUri;
+        if (jwkUrl != null)
+        {
+          var jwkClone = request.Clone<JsonWebKeySetRequest>();
+          jwkClone.Method = HttpMethod.Get;
+          jwkClone.Address = jwkUrl;
+          jwkClone.Prepare();
+
+          var jwkResponse = await client.GetJsonWebKeySetAsync(jwkClone, cancellationToken).ConfigureAwait();
+
+          if (jwkResponse.IsError)
+          {
+            if (jwkResponse.Exception != null)
+            {
+              return ProtocolResponse.FromException<DiscoveryDocumentResponse>(jwkResponse.Exception, jwkResponse.Error);
+            }
+            else if (jwkResponse.HttpResponse != null)
+            {
+              return await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(jwkResponse.HttpResponse, $"Error connecting to {jwkUrl}: {jwkResponse.HttpErrorReason}").ConfigureAwait();
+            }
+            // If IsError is true, but we have neither an Exception nor an HttpResponse, something very weird is going on
+            // I don't think it is actually possible for this to occur, but just in case...
+            else
+            {
+              return ProtocolResponse.FromException<DiscoveryDocumentResponse>(
+                  new ArgumentNullException(nameof(jwkResponse.HttpResponse)), $"Unknown error retrieving JWKS - neither an exception nor an HttpResponse is available");
+            }
+          }
+
+          disco.KeySet = jwkResponse.KeySet;
+        }
+
+        return disco;
+      }
+      catch (OperationCanceledException)
+      {
+        throw;
+      }
+      catch (Exception ex)
+      {
+        return ProtocolResponse.FromException<DiscoveryDocumentResponse>(ex, $"Error connecting to {jwkUrl}. {ex.Message}.");
+      }
+    }
+    catch (OperationCanceledException)
+    {
+      throw;
+    }
+    catch (Exception ex)
+    {
+      return ProtocolResponse.FromException<DiscoveryDocumentResponse>(ex, $"Error connecting to {url}. {ex.Message}.");
+    }
+  }
 }

--- a/src/Client/Extensions/HttpClientJsonWebKeySetExtensions.cs
+++ b/src/Client/Extensions/HttpClientJsonWebKeySetExtensions.cs
@@ -15,56 +15,56 @@ namespace IdentityModel.Client;
 /// </summary>
 public static class HttpClientJsonWebKeySetExtensions
 {
-    /// <summary>
-    /// Sends a JSON web key set document request
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="address"></param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<JsonWebKeySetResponse> GetJsonWebKeySetAsync(this HttpMessageInvoker client, string? address = null, CancellationToken cancellationToken = default)
+  /// <summary>
+  /// Sends a JSON web key set document request
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="address"></param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<JsonWebKeySetResponse> GetJsonWebKeySetAsync(this HttpMessageInvoker client, string? address = null, CancellationToken cancellationToken = default)
+  {
+    return await client.GetJsonWebKeySetAsync(new JsonWebKeySetRequest
     {
-        return await client.GetJsonWebKeySetAsync(new JsonWebKeySetRequest
-        {
-            Address = address
-        }, cancellationToken).ConfigureAwait();
+      Address = address
+    }, cancellationToken).ConfigureAwait();
+  }
+
+  /// <summary>
+  /// Sends a JSON web key set document request
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<JsonWebKeySetResponse> GetJsonWebKeySetAsync(this HttpMessageInvoker client, JsonWebKeySetRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    clone.Method = HttpMethod.Get;
+    clone.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/jwk-set+json"));
+    clone.Prepare();
+
+
+    try
+    {
+      using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+
+      if (!response.IsSuccessStatusCode)
+      {
+        return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response, $"Error connecting to {clone.RequestUri!.AbsoluteUri}: {response.ReasonPhrase}").ConfigureAwait();
+      }
+      return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response).ConfigureAwait();
+
+    }
+    catch (OperationCanceledException)
+    {
+      throw;
+    }
+    catch (Exception ex)
+    {
+      return ProtocolResponse.FromException<JsonWebKeySetResponse>(ex, $"Error connecting to {clone.RequestUri!.AbsoluteUri}. {ex.Message}.");
     }
 
-    /// <summary>
-    /// Sends a JSON web key set document request
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<JsonWebKeySetResponse> GetJsonWebKeySetAsync(this HttpMessageInvoker client, JsonWebKeySetRequest request, CancellationToken cancellationToken = default)
-    {
-        var clone = request.Clone();
-
-        clone.Method = HttpMethod.Get;
-        clone.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/jwk-set+json"));
-        clone.Prepare();
-
-        HttpResponseMessage response;
-
-        try
-        {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
-
-            if (!response.IsSuccessStatusCode)
-            {
-                return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response, $"Error connecting to {clone.RequestUri!.AbsoluteUri}: {response.ReasonPhrase}").ConfigureAwait();
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            return ProtocolResponse.FromException<JsonWebKeySetResponse>(ex, $"Error connecting to {clone.RequestUri!.AbsoluteUri}. {ex.Message}.");
-        }
-
-        return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response).ConfigureAwait();
-    }
+  }
 }

--- a/src/Client/Extensions/HttpClientPushedAuthorizationExtensions.cs
+++ b/src/Client/Extensions/HttpClientPushedAuthorizationExtensions.cs
@@ -14,79 +14,79 @@ namespace IdentityModel.Client;
 /// </summary>
 public static class HttpClientPushedAuthorizationExtensions
 {
-    /// <summary>
-    /// Sends a pushed authorization request
-    /// </summary>
-    /// <param name="client">The HTTP client.</param>
-    /// <param name="request"></param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static Task<PushedAuthorizationResponse> PushAuthorizationAsync(this HttpClient client, PushedAuthorizationRequest request, CancellationToken cancellationToken = default)
+  /// <summary>
+  /// Sends a pushed authorization request
+  /// </summary>
+  /// <param name="client">The HTTP client.</param>
+  /// <param name="request"></param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static Task<PushedAuthorizationResponse> PushAuthorizationAsync(this HttpClient client, PushedAuthorizationRequest request, CancellationToken cancellationToken = default)
+  {
+    if (request.Parameters.ContainsKey(OidcConstants.AuthorizeRequest.RequestUri))
     {
-        if(request.Parameters.ContainsKey(OidcConstants.AuthorizeRequest.RequestUri))
-        {
-            throw new ArgumentException("request_uri cannot be used in a pushed authorization request", "request_uri");
-        }
-
-        var clone = request.Clone();
-
-        // client id is always required, and will be added by the call to
-        // Prepare() for other client credential styles.
-        if(request.ClientCredentialStyle == ClientCredentialStyle.AuthorizationHeader)
-        {
-            clone.Parameters.AddRequired(OidcConstants.AuthorizeRequest.ClientId, request.ClientId);
-        }
-
-        if (request.Request.IsPresent() || request.Parameters.ContainsKey(OidcConstants.AuthorizeRequest.Request))
-        {
-            clone.Parameters.AddRequired(OidcConstants.AuthorizeRequest.Request, request.Request);
-        } 
-        else
-        {
-            clone.Parameters.AddRequired(OidcConstants.AuthorizeRequest.ResponseType, request.ResponseType);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Scope, request.Scope);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.RedirectUri, request.RedirectUri);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.State, request.State);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Nonce, request.Nonce);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.LoginHint, request.LoginHint);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.AcrValues, request.AcrValues);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Prompt, request.Prompt);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.ResponseMode, request.ResponseMode);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.CodeChallenge, request.CodeChallenge);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.CodeChallengeMethod, request.CodeChallengeMethod);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Display, request.Display);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.MaxAge, request.MaxAge.ToString());
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.UiLocales, request.UiLocales);
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.IdTokenHint, request.IdTokenHint);
-            foreach(var resource in request.Resource ?? [])
-            {
-                clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Resource, resource, allowDuplicates: true);
-            }
-            clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint, request.DPoPKeyThumbprint);
-        }
-
-        return PushAuthorizationAsync(client, clone, cancellationToken);
+      throw new ArgumentException("request_uri cannot be used in a pushed authorization request", "request_uri");
     }
 
-    internal static async Task<PushedAuthorizationResponse> PushAuthorizationAsync(this HttpMessageInvoker client, ProtocolRequest request, CancellationToken cancellationToken = default)
-    {
-        request.Prepare();
-        request.Method = HttpMethod.Post;
-            
-        HttpResponseMessage response;
-        try
-        {
-            response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
-        }
-        catch (OperationCanceledException)
-		{
-            throw;
-		}
-        catch (Exception ex)
-        {
-            return ProtocolResponse.FromException<PushedAuthorizationResponse>(ex);
-        }
+    ProtocolRequest clone = request.Clone();
 
-        return await ProtocolResponse.FromHttpResponseAsync<PushedAuthorizationResponse>(response).ConfigureAwait();
+    // client id is always required, and will be added by the call to
+    // Prepare() for other client credential styles.
+    if (request.ClientCredentialStyle == ClientCredentialStyle.AuthorizationHeader)
+    {
+      clone.Parameters.AddRequired(OidcConstants.AuthorizeRequest.ClientId, request.ClientId);
     }
+
+    if (request.Request.IsPresent() || request.Parameters.ContainsKey(OidcConstants.AuthorizeRequest.Request))
+    {
+      clone.Parameters.AddRequired(OidcConstants.AuthorizeRequest.Request, request.Request);
+    }
+    else
+    {
+      clone.Parameters.AddRequired(OidcConstants.AuthorizeRequest.ResponseType, request.ResponseType);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Scope, request.Scope);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.RedirectUri, request.RedirectUri);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.State, request.State);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Nonce, request.Nonce);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.LoginHint, request.LoginHint);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.AcrValues, request.AcrValues);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Prompt, request.Prompt);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.ResponseMode, request.ResponseMode);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.CodeChallenge, request.CodeChallenge);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.CodeChallengeMethod, request.CodeChallengeMethod);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Display, request.Display);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.MaxAge, request.MaxAge.ToString());
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.UiLocales, request.UiLocales);
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.IdTokenHint, request.IdTokenHint);
+      foreach (string resource in request.Resource ?? [])
+      {
+        clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Resource, resource, allowDuplicates: true);
+      }
+      clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint, request.DPoPKeyThumbprint);
+    }
+
+    return PushAuthorizationAsync(client, clone, cancellationToken);
+  }
+
+  internal static async Task<PushedAuthorizationResponse> PushAuthorizationAsync(this HttpMessageInvoker client, ProtocolRequest request, CancellationToken cancellationToken = default)
+  {
+    request.Prepare();
+    request.Method = HttpMethod.Post;
+
+    try
+    {
+      using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
+      return await ProtocolResponse.FromHttpResponseAsync<PushedAuthorizationResponse>(response).ConfigureAwait();
+
+    }
+    catch (OperationCanceledException)
+    {
+      throw;
+    }
+    catch (Exception ex)
+    {
+      return ProtocolResponse.FromException<PushedAuthorizationResponse>(ex);
+    }
+     
+  }
 }

--- a/src/Client/Extensions/HttpClientTokenIntrospectionExtensions.cs
+++ b/src/Client/Extensions/HttpClientTokenIntrospectionExtensions.cs
@@ -14,36 +14,37 @@ namespace IdentityModel.Client;
 /// </summary>
 public static class HttpClientTokenIntrospectionExtensions
 {
-    /// <summary>
-    /// Sends an OAuth token introspection request.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<TokenIntrospectionResponse> IntrospectTokenAsync(this HttpMessageInvoker client, TokenIntrospectionRequest request, CancellationToken cancellationToken = default)
+  /// <summary>
+  /// Sends an OAuth token introspection request.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<TokenIntrospectionResponse> IntrospectTokenAsync(this HttpMessageInvoker client, TokenIntrospectionRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    clone.Method = HttpMethod.Post;
+    clone.Parameters.AddRequired(OidcConstants.TokenIntrospectionRequest.Token, request.Token);
+    clone.Parameters.AddOptional(OidcConstants.TokenIntrospectionRequest.TokenTypeHint, request.TokenTypeHint);
+    clone.Prepare();
+
+    
+    try
     {
-        var clone = request.Clone();
+      using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+      return await ProtocolResponse.FromHttpResponseAsync<TokenIntrospectionResponse>(response).ConfigureAwait();
 
-        clone.Method = HttpMethod.Post;
-        clone.Parameters.AddRequired(OidcConstants.TokenIntrospectionRequest.Token, request.Token);
-        clone.Parameters.AddOptional(OidcConstants.TokenIntrospectionRequest.TokenTypeHint, request.TokenTypeHint);
-        clone.Prepare();
-
-        HttpResponseMessage response;
-        try
-        {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            return ProtocolResponse.FromException<TokenIntrospectionResponse>(ex);
-        }
-
-        return await ProtocolResponse.FromHttpResponseAsync<TokenIntrospectionResponse>(response).ConfigureAwait();
     }
+    catch (OperationCanceledException)
+    {
+      throw;
+    }
+    catch (Exception ex)
+    {
+      return ProtocolResponse.FromException<TokenIntrospectionResponse>(ex);
+    }
+     
+  }
 }

--- a/src/Client/Extensions/HttpClientTokenRequestExtensions.cs
+++ b/src/Client/Extensions/HttpClientTokenRequestExtensions.cs
@@ -14,223 +14,224 @@ namespace IdentityModel.Client;
 /// </summary>
 public static class HttpClientTokenRequestExtensions
 {
-    /// <summary>
-    /// Sends a token request using the client_credentials grant type.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<TokenResponse> RequestClientCredentialsTokenAsync(this HttpMessageInvoker client, ClientCredentialsTokenRequest request, CancellationToken cancellationToken = default)
+  /// <summary>
+  /// Sends a token request using the client_credentials grant type.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<TokenResponse> RequestClientCredentialsTokenAsync(this HttpMessageInvoker client, ClientCredentialsTokenRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.ClientCredentials);
+    clone.Parameters.AddOptional(OidcConstants.TokenRequest.Scope, request.Scope);
+
+    foreach (var resource in request.Resource)
     {
-        var clone = request.Clone();
-
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.ClientCredentials);
-        clone.Parameters.AddOptional(OidcConstants.TokenRequest.Scope, request.Scope);
-            
-        foreach (var resource in request.Resource)
-        {
-            clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
-        }
-
-        return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+      clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
     }
 
-    /// <summary>
-    /// Sends a token request using the urn:ietf:params:oauth:grant-type:device_code grant type.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<TokenResponse> RequestDeviceTokenAsync(this HttpMessageInvoker client, DeviceTokenRequest request, CancellationToken cancellationToken = default)
-    {
-        var clone = request.Clone();
+    return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+  }
 
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.DeviceCode);
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.DeviceCode, request.DeviceCode);
-            
-        return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+  /// <summary>
+  /// Sends a token request using the urn:ietf:params:oauth:grant-type:device_code grant type.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<TokenResponse> RequestDeviceTokenAsync(this HttpMessageInvoker client, DeviceTokenRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.DeviceCode);
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.DeviceCode, request.DeviceCode);
+
+    return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+  }
+
+  /// <summary>
+  /// Sends a token request using the password grant type.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<TokenResponse> RequestPasswordTokenAsync(this HttpMessageInvoker client, PasswordTokenRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.Password);
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.UserName, request.UserName);
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.Password, request.Password, allowEmptyValue: true);
+    clone.Parameters.AddOptional(OidcConstants.TokenRequest.Scope, request.Scope);
+
+    foreach (var resource in request.Resource)
+    {
+      clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
     }
 
-    /// <summary>
-    /// Sends a token request using the password grant type.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<TokenResponse> RequestPasswordTokenAsync(this HttpMessageInvoker client, PasswordTokenRequest request, CancellationToken cancellationToken = default)
+    return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+  }
+
+  /// <summary>
+  /// Sends a token request using the authorization_code grant type.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<TokenResponse> RequestAuthorizationCodeTokenAsync(this HttpMessageInvoker client, AuthorizationCodeTokenRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.AuthorizationCode);
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.Code, request.Code);
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.RedirectUri, request.RedirectUri);
+    clone.Parameters.AddOptional(OidcConstants.TokenRequest.CodeVerifier, request.CodeVerifier);
+
+    foreach (var resource in request.Resource)
     {
-        var clone = request.Clone();
-
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.Password);
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.UserName, request.UserName);
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.Password, request.Password, allowEmptyValue: true);
-        clone.Parameters.AddOptional(OidcConstants.TokenRequest.Scope, request.Scope);
-            
-        foreach (var resource in request.Resource)
-        {
-            clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
-        }
-
-        return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+      clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
     }
 
-    /// <summary>
-    /// Sends a token request using the authorization_code grant type.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<TokenResponse> RequestAuthorizationCodeTokenAsync(this HttpMessageInvoker client, AuthorizationCodeTokenRequest request, CancellationToken cancellationToken = default)
+    return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+  }
+
+  /// <summary>
+  /// Sends a token request using the refresh_token grant type.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<TokenResponse> RequestRefreshTokenAsync(this HttpMessageInvoker client, RefreshTokenRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.RefreshToken);
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.RefreshToken, request.RefreshToken);
+    clone.Parameters.AddOptional(OidcConstants.TokenRequest.Scope, request.Scope);
+
+    foreach (var resource in request.Resource)
     {
-        var clone = request.Clone();
-
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.AuthorizationCode);
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.Code, request.Code);
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.RedirectUri, request.RedirectUri);
-        clone.Parameters.AddOptional(OidcConstants.TokenRequest.CodeVerifier, request.CodeVerifier);
-
-        foreach (var resource in request.Resource)
-        {
-            clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
-        }
-
-        return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+      clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
     }
 
-    /// <summary>
-    /// Sends a token request using the refresh_token grant type.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<TokenResponse> RequestRefreshTokenAsync(this HttpMessageInvoker client, RefreshTokenRequest request, CancellationToken cancellationToken = default)
+    return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+  }
+
+  /// <summary>
+  /// Sends a token exchange request.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<TokenResponse> RequestTokenExchangeTokenAsync(this HttpMessageInvoker client, TokenExchangeTokenRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.TokenExchange);
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.SubjectToken, request.SubjectToken);
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.SubjectTokenType, request.SubjectTokenType);
+
+    clone.Parameters.AddOptional(OidcConstants.TokenRequest.Resource, request.Resource);
+    clone.Parameters.AddOptional(OidcConstants.TokenRequest.Audience, request.Audience);
+    clone.Parameters.AddOptional(OidcConstants.TokenRequest.Scope, request.Scope);
+    clone.Parameters.AddOptional(OidcConstants.TokenRequest.RequestedTokenType, request.RequestedTokenType);
+    clone.Parameters.AddOptional(OidcConstants.TokenRequest.ActorToken, request.ActorToken);
+    clone.Parameters.AddOptional(OidcConstants.TokenRequest.ActorTokenType, request.ActorTokenType);
+
+    return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+  }
+
+  /// <summary>
+  /// Sends a token request using the urn:openid:params:grant-type:ciba grant type.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<TokenResponse> RequestBackchannelAuthenticationTokenAsync(this HttpMessageInvoker client, BackchannelAuthenticationTokenRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.Ciba);
+    clone.Parameters.AddRequired(OidcConstants.TokenRequest.AuthenticationRequestId, request.AuthenticationRequestId);
+
+    foreach (var resource in request.Resource)
     {
-        var clone = request.Clone();
-
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.RefreshToken);
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.RefreshToken, request.RefreshToken);
-        clone.Parameters.AddOptional(OidcConstants.TokenRequest.Scope, request.Scope);
-            
-        foreach (var resource in request.Resource)
-        {
-            clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
-        }
-
-        return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
-    }
-        
-    /// <summary>
-    /// Sends a token exchange request.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<TokenResponse> RequestTokenExchangeTokenAsync(this HttpMessageInvoker client, TokenExchangeTokenRequest request, CancellationToken cancellationToken = default)
-    {
-        var clone = request.Clone();
-
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.TokenExchange);
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.SubjectToken, request.SubjectToken);
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.SubjectTokenType, request.SubjectTokenType);
-            
-        clone.Parameters.AddOptional(OidcConstants.TokenRequest.Resource, request.Resource);
-        clone.Parameters.AddOptional(OidcConstants.TokenRequest.Audience, request.Audience);
-        clone.Parameters.AddOptional(OidcConstants.TokenRequest.Scope, request.Scope);
-        clone.Parameters.AddOptional(OidcConstants.TokenRequest.RequestedTokenType, request.RequestedTokenType);
-        clone.Parameters.AddOptional(OidcConstants.TokenRequest.ActorToken, request.ActorToken);
-        clone.Parameters.AddOptional(OidcConstants.TokenRequest.ActorTokenType, request.ActorTokenType);
-            
-        return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
-    }
-    
-    /// <summary>
-    /// Sends a token request using the urn:openid:params:grant-type:ciba grant type.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<TokenResponse> RequestBackchannelAuthenticationTokenAsync(this HttpMessageInvoker client, BackchannelAuthenticationTokenRequest request, CancellationToken cancellationToken = default)
-    {
-        var clone = request.Clone();
-
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.Ciba);
-        clone.Parameters.AddRequired(OidcConstants.TokenRequest.AuthenticationRequestId, request.AuthenticationRequestId);
-            
-        foreach (var resource in request.Resource)
-        {
-            clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
-        }
-
-        return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+      clone.Parameters.AddRequired(OidcConstants.TokenRequest.Resource, resource, allowDuplicates: true);
     }
 
-    /// <summary>
-    /// Sends a token request.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<TokenResponse> RequestTokenAsync(this HttpMessageInvoker client, TokenRequest request, CancellationToken cancellationToken = default)
+    return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+  }
+
+  /// <summary>
+  /// Sends a token request.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<TokenResponse> RequestTokenAsync(this HttpMessageInvoker client, TokenRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    if (!clone.Parameters.ContainsKey(OidcConstants.TokenRequest.GrantType))
     {
-        var clone = request.Clone();
-
-        if (!clone.Parameters.ContainsKey(OidcConstants.TokenRequest.GrantType))
-        {
-            clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, request.GrantType);
-        }
-
-        return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+      clone.Parameters.AddRequired(OidcConstants.TokenRequest.GrantType, request.GrantType);
     }
 
-    /// <summary>
-    /// Sends a token request.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="address">The address.</param>
-    /// <param name="parameters">The parameters.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentNullException">parameters</exception>
-    public static async Task<TokenResponse> RequestTokenRawAsync(this HttpMessageInvoker client, string address, Parameters parameters, CancellationToken cancellationToken = default)
+    return await client.RequestTokenAsync(clone, cancellationToken).ConfigureAwait();
+  }
+
+  /// <summary>
+  /// Sends a token request.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="address">The address.</param>
+  /// <param name="parameters">The parameters.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  /// <exception cref="ArgumentNullException">parameters</exception>
+  public static async Task<TokenResponse> RequestTokenRawAsync(this HttpMessageInvoker client, string address, Parameters parameters, CancellationToken cancellationToken = default)
+  {
+    if (parameters == null) throw new ArgumentNullException(nameof(parameters));
+
+    var request = new TokenRequest
     {
-        if (parameters == null) throw new ArgumentNullException(nameof(parameters));
+      Address = address,
+      Parameters = parameters
+    };
 
-        var request = new TokenRequest
-        {
-            Address = address,
-            Parameters = parameters
-        };
+    return await client.RequestTokenAsync(request, cancellationToken).ConfigureAwait();
+  }
 
-        return await client.RequestTokenAsync(request, cancellationToken).ConfigureAwait();
+  internal static async Task<TokenResponse> RequestTokenAsync(this HttpMessageInvoker client, ProtocolRequest request, CancellationToken cancellationToken = default)
+  {
+    request.Prepare();
+    request.Method = HttpMethod.Post;
+
+
+    try
+    {
+      using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
+      return await ProtocolResponse.FromHttpResponseAsync<TokenResponse>(response).ConfigureAwait();
+
+    }
+    catch (OperationCanceledException)
+    {
+      throw;
+    }
+    catch (Exception ex)
+    {
+      return ProtocolResponse.FromException<TokenResponse>(ex);
     }
 
-    internal static async Task<TokenResponse> RequestTokenAsync(this HttpMessageInvoker client, ProtocolRequest request, CancellationToken cancellationToken = default)
-    {
-        request.Prepare();
-        request.Method = HttpMethod.Post;
-            
-        HttpResponseMessage response;
-        try
-        {
-            response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
-        }
-        catch (OperationCanceledException)
-		{
-            throw;
-		}
-        catch (Exception ex)
-        {
-            return ProtocolResponse.FromException<TokenResponse>(ex);
-        }
-
-        return await ProtocolResponse.FromHttpResponseAsync<TokenResponse>(response).ConfigureAwait();
-    }
+  }
 }

--- a/src/Client/Extensions/HttpClientTokenRevocationExtensions.cs
+++ b/src/Client/Extensions/HttpClientTokenRevocationExtensions.cs
@@ -14,36 +14,37 @@ namespace IdentityModel.Client;
 /// </summary>
 public static class HttpClientTokenRevocationExtensions
 {
-    /// <summary>
-    /// Sends an OAuth token revocation request.
-    /// </summary>
-    /// <param name="client">The client.</param>
-    /// <param name="request">The request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
-    public static async Task<TokenRevocationResponse> RevokeTokenAsync(this HttpMessageInvoker client, TokenRevocationRequest request, CancellationToken cancellationToken = default)
+  /// <summary>
+  /// Sends an OAuth token revocation request.
+  /// </summary>
+  /// <param name="client">The client.</param>
+  /// <param name="request">The request.</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns></returns>
+  public static async Task<TokenRevocationResponse> RevokeTokenAsync(this HttpMessageInvoker client, TokenRevocationRequest request, CancellationToken cancellationToken = default)
+  {
+    var clone = request.Clone();
+
+    clone.Method = HttpMethod.Post;
+    clone.Parameters.AddRequired(OidcConstants.TokenIntrospectionRequest.Token, request.Token);
+    clone.Parameters.AddOptional(OidcConstants.TokenIntrospectionRequest.TokenTypeHint, request.TokenTypeHint);
+    clone.Prepare();
+
+
+    try
     {
-        var clone = request.Clone();
+      using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+      return await ProtocolResponse.FromHttpResponseAsync<TokenRevocationResponse>(response).ConfigureAwait();
 
-        clone.Method = HttpMethod.Post;
-        clone.Parameters.AddRequired(OidcConstants.TokenIntrospectionRequest.Token, request.Token);
-        clone.Parameters.AddOptional(OidcConstants.TokenIntrospectionRequest.TokenTypeHint, request.TokenTypeHint);
-        clone.Prepare();
-
-        HttpResponseMessage response;
-        try
-        {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            return ProtocolResponse.FromException<TokenRevocationResponse>(ex);
-        }
-
-        return await ProtocolResponse.FromHttpResponseAsync<TokenRevocationResponse>(response).ConfigureAwait();
     }
+    catch (OperationCanceledException)
+    {
+      throw;
+    }
+    catch (Exception ex)
+    {
+      return ProtocolResponse.FromException<TokenRevocationResponse>(ex);
+    }
+
+  }
 }

--- a/test/UnitTests/HttpClientExtensions/DiscoveryExtensionsTests.cs
+++ b/test/UnitTests/HttpClientExtensions/DiscoveryExtensionsTests.cs
@@ -365,7 +365,7 @@ namespace IdentityModel.UnitTests
             disco.ErrorType.Should().Be(ResponseErrorType.Http);
             disco.HttpStatusCode.Should().Be(HttpStatusCode.InternalServerError);
             disco.Error.Should().Contain("Internal Server Error");
-            disco.Raw.Should().Be("not_json");
+            disco.Raw.Should().Be(null);
             disco.Json?.ValueKind.Should().Be(JsonValueKind.Undefined);
         }
 


### PR DESCRIPTION
- Updated `try-catch` blocks to use `using` for `HttpResponseMessage` to ensure proper disposal.
- Modified a test in `DiscoveryExtensionsTests.cs` to expect `disco.Raw` to be `null` on internal server error.