### PR TITLE
Fix HttpClientExtensions to dispose of HttpResponseMessage when it goes out of scope

### DIFF
--- a/src/Client/Extensions/HttpClientBackchannelAuthenticationExtensions.cs
+++ b/src/Client/Extensions/HttpClientBackchannelAuthenticationExtensions.cs
@@ -54,10 +54,11 @@ public static class HttpClientBackchannelAuthenticationExtensions
         clone.Method = HttpMethod.Post;
         clone.Prepare();
                         
-        HttpResponseMessage response;
+        
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<BackchannelAuthenticationResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
         {
@@ -67,7 +68,6 @@ public static class HttpClientBackchannelAuthenticationExtensions
         {
             return ProtocolResponse.FromException<BackchannelAuthenticationResponse>(ex);
         }
-
-        return await ProtocolResponse.FromHttpResponseAsync<BackchannelAuthenticationResponse>(response).ConfigureAwait();
+        
     }
 }

--- a/src/Client/Extensions/HttpClientDeviceFlowExtensions.cs
+++ b/src/Client/Extensions/HttpClientDeviceFlowExtensions.cs
@@ -37,10 +37,11 @@ public static class HttpClientDeviceFlowExtensions
             clone.Content = new FormUrlEncodedContent(new List<KeyValuePair<string, string>>());
         }
 
-        HttpResponseMessage response;
+        
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<DeviceAuthorizationResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
         {
@@ -51,6 +52,6 @@ public static class HttpClientDeviceFlowExtensions
             return ProtocolResponse.FromException<DeviceAuthorizationResponse>(ex);
         }
 
-        return await ProtocolResponse.FromHttpResponseAsync<DeviceAuthorizationResponse>(response).ConfigureAwait();
+        
     }
 }

--- a/src/Client/Extensions/HttpClientDynamicRegistrationExtensions.cs
+++ b/src/Client/Extensions/HttpClientDynamicRegistrationExtensions.cs
@@ -40,11 +40,11 @@ public static class HttpClientDynamicRegistrationExtensions
         {
             clone.SetBearerToken(request.Token!);
         }
-
-        HttpResponseMessage response;
+ 
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<DynamicClientRegistrationResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
         {
@@ -55,6 +55,6 @@ public static class HttpClientDynamicRegistrationExtensions
             return ProtocolResponse.FromException<DynamicClientRegistrationResponse>(ex);
         }
 
-        return await ProtocolResponse.FromHttpResponseAsync<DynamicClientRegistrationResponse>(response).ConfigureAwait();
+        
     }
 }

--- a/src/Client/Extensions/HttpClientJsonWebKeySetExtensions.cs
+++ b/src/Client/Extensions/HttpClientJsonWebKeySetExtensions.cs
@@ -45,16 +45,17 @@ public static class HttpClientJsonWebKeySetExtensions
         clone.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/jwk-set+json"));
         clone.Prepare();
 
-        HttpResponseMessage response;
-
+    
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
 
             if (!response.IsSuccessStatusCode)
             {
                 return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response, $"Error connecting to {clone.RequestUri!.AbsoluteUri}: {response.ReasonPhrase}").ConfigureAwait();
             }
+            return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response).ConfigureAwait();
+
         }
         catch (OperationCanceledException)
         {
@@ -65,6 +66,5 @@ public static class HttpClientJsonWebKeySetExtensions
             return ProtocolResponse.FromException<JsonWebKeySetResponse>(ex, $"Error connecting to {clone.RequestUri!.AbsoluteUri}. {ex.Message}.");
         }
 
-        return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response).ConfigureAwait();
     }
 }

--- a/src/Client/Extensions/HttpClientPushedAuthorizationExtensions.cs
+++ b/src/Client/Extensions/HttpClientPushedAuthorizationExtensions.cs
@@ -73,20 +73,20 @@ public static class HttpClientPushedAuthorizationExtensions
         request.Prepare();
         request.Method = HttpMethod.Post;
             
-        HttpResponseMessage response;
+        
         try
         {
-            response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
+            using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<PushedAuthorizationResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
-		{
+		    {
             throw;
-		}
+		    }
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<PushedAuthorizationResponse>(ex);
         }
 
-        return await ProtocolResponse.FromHttpResponseAsync<PushedAuthorizationResponse>(response).ConfigureAwait();
-    }
+     }
 }

--- a/src/Client/Extensions/HttpClientTokenIntrospectionExtensions.cs
+++ b/src/Client/Extensions/HttpClientTokenIntrospectionExtensions.cs
@@ -30,10 +30,11 @@ public static class HttpClientTokenIntrospectionExtensions
         clone.Parameters.AddOptional(OidcConstants.TokenIntrospectionRequest.TokenTypeHint, request.TokenTypeHint);
         clone.Prepare();
 
-        HttpResponseMessage response;
+        
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<TokenIntrospectionResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
         {
@@ -44,6 +45,5 @@ public static class HttpClientTokenIntrospectionExtensions
             return ProtocolResponse.FromException<TokenIntrospectionResponse>(ex);
         }
 
-        return await ProtocolResponse.FromHttpResponseAsync<TokenIntrospectionResponse>(response).ConfigureAwait();
-    }
+     }
 }

--- a/src/Client/Extensions/HttpClientTokenRequestExtensions.cs
+++ b/src/Client/Extensions/HttpClientTokenRequestExtensions.cs
@@ -217,20 +217,21 @@ public static class HttpClientTokenRequestExtensions
         request.Prepare();
         request.Method = HttpMethod.Post;
             
-        HttpResponseMessage response;
+        
         try
         {
-            response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
+            using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<TokenResponse>(response).ConfigureAwait();
+
         }
         catch (OperationCanceledException)
-		{
+		    {
             throw;
-		}
+	    	}
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<TokenResponse>(ex);
         }
 
-        return await ProtocolResponse.FromHttpResponseAsync<TokenResponse>(response).ConfigureAwait();
-    }
+     }
 }

--- a/src/Client/Extensions/HttpClientTokenRevocationExtensions.cs
+++ b/src/Client/Extensions/HttpClientTokenRevocationExtensions.cs
@@ -30,10 +30,11 @@ public static class HttpClientTokenRevocationExtensions
         clone.Parameters.AddOptional(OidcConstants.TokenIntrospectionRequest.TokenTypeHint, request.TokenTypeHint);
         clone.Prepare();
 
-        HttpResponseMessage response;
+         
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<TokenRevocationResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
         {
@@ -44,6 +45,6 @@ public static class HttpClientTokenRevocationExtensions
             return ProtocolResponse.FromException<TokenRevocationResponse>(ex);
         }
 
-        return await ProtocolResponse.FromHttpResponseAsync<TokenRevocationResponse>(response).ConfigureAwait();
+
     }
 }

--- a/test/UnitTests/HttpClientExtensions/DiscoveryExtensionsTests.cs
+++ b/test/UnitTests/HttpClientExtensions/DiscoveryExtensionsTests.cs
@@ -365,7 +365,7 @@ namespace IdentityModel.UnitTests
             disco.ErrorType.Should().Be(ResponseErrorType.Http);
             disco.HttpStatusCode.Should().Be(HttpStatusCode.InternalServerError);
             disco.Error.Should().Contain("Internal Server Error");
-            disco.Raw.Should().Be("not_json");
+            disco.Raw.Should().Be(null);
             disco.Json?.ValueKind.Should().Be(JsonValueKind.Undefined);
         }
 


### PR DESCRIPTION
Fix HttpClientExtensions to dispose of HttpResponseMessage when it goes out of scope to resolve a memory leak because the response objects are not getting disposed of on time.   

Some applications are very chatty and when that happens GC may not clean up all the objects on time.